### PR TITLE
Add support for creating an instance group of mixed instance types

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ This allows the user to more easily generate type-safe Kops configuration, throu
 ## Install
 For stability, users are encouraged to import from a tagged release, not from the master branch, and to watch for new releases. This project does not yet have rigorous testing set up for it and new commits on the master branch are prone to break compatiblility and are almost sure to change the import hash for the expression, thus the releases are currently `v0.x`.
 ```
-https://raw.githubusercontent.com/coralogix/dhall-kops/v0.2.0/defaults/package.dhall sha256:0676ecdc8e7ee0883058a17342b3ceba54b6bc4ecea222b27cdbe55bf4476427
-https://raw.githubusercontent.com/coralogix/dhall-kops/v0.2.0/types/package.dhall sha256:5651acaae268747be32d333552523915effabe3f50eb771c5e70862c54743bc3
+https://raw.githubusercontent.com/coralogix/dhall-kops/v0.3.0/defaults/package.dhall sha256:441779fcf142d88aab395b8658dcd37600e62dd6d13d283a68c6dfb359790bff
+https://raw.githubusercontent.com/coralogix/dhall-kops/v0.3.0/types/package.dhall sha256:cada144be476dca5fa4da4ed2929301cd04312324970cde1102981d7cae283b7
 ```
 
 ## Usage

--- a/defaults/api/v1alpha2/instanceGroupSpec.dhall
+++ b/defaults/api/v1alpha2/instanceGroupSpec.dhall
@@ -1,3 +1,6 @@
+let MixedInstancesPolicySpec =
+      ../../../types/api/v1alpha2/MixedInstancesPolicySpec.dhall : Type
+
 let UserData = ../../../types/api/v1alpha2/UserData.dhall : Type
 
 let LoadBalancer = ../../../types/api/v1alpha2/LoadBalancer.dhall : Type
@@ -31,6 +34,8 @@ in  { rootVolumeSize =
         None (List HookSpec.Union)
     , maxPrice =
         None Text
+    , mixedInstancesPolicy =
+        None MixedInstancesPolicySpec
     , associatePublicIp =
         None Bool
     , additionalSecurityGroups =

--- a/defaults/api/v1alpha2/mixedInstancesPolicySpec.dhall
+++ b/defaults/api/v1alpha2/mixedInstancesPolicySpec.dhall
@@ -1,0 +1,17 @@
+let MixedInstancesPolicySpec =
+      ../../../types/api/v1alpha2/MixedInstancesPolicySpec.dhall
+
+in    { instances =
+          None (List Text)
+      , onDemandAllocationStrategy =
+          None Text
+      , onDemandBase =
+          None Natural
+      , onDemandAboveBase =
+          None Natural
+      , spotAllocationStrategy =
+          None Text
+      , spotInstancePools =
+          None Text
+      }
+    : MixedInstancesPolicySpec

--- a/defaults/api/v1alpha2/package.dhall
+++ b/defaults/api/v1alpha2/package.dhall
@@ -82,6 +82,8 @@
     ./loadBalancerAccessSpec.dhall
 , metadata =
     ./metadata.dhall
+, mixedInstancesPolicySpec =
+    ./mixedInstancesPolicySpec.dhall
 , networkingSpec =
     ./networkingSpec.dhall
 , nodeAuthorizationSpec =

--- a/tests/api/v1alpha2/tests.dhall
+++ b/tests/api/v1alpha2/tests.dhall
@@ -219,6 +219,8 @@ in  { accessSpec =
     , loadBalancerAccessSpec =
           defaults.loadBalancerAccessSpec ∧ { type = "example" }
         : Types.LoadBalancerAccessSpec
+    , mixedInstancesPolicySpec =
+        defaults.mixedInstancesPolicySpec : Types.MixedInstancesPolicySpec
     , networking =
         { amazonVPC =
             defaults.networking.amazonVPC : Types.Networking.AmazonVPC

--- a/types/api/v1alpha2/InstanceGroupSpec.dhall
+++ b/types/api/v1alpha2/InstanceGroupSpec.dhall
@@ -1,3 +1,5 @@
+let MixedInstancesPolicySpec = ./MixedInstancesPolicySpec.dhall : Type
+
 let UserData = ./UserData.dhall : Type
 
 let LoadBalancer = ./LoadBalancer.dhall : Type
@@ -24,6 +26,8 @@ in    { role :
           Natural
       , machineType :
           Text
+      , mixedInstancesPolicy :
+          Optional MixedInstancesPolicySpec
       , rootVolumeSize :
           Optional Natural
       , rootVolumeType :

--- a/types/api/v1alpha2/MixedInstancesPolicySpec.dhall
+++ b/types/api/v1alpha2/MixedInstancesPolicySpec.dhall
@@ -1,0 +1,14 @@
+  { instances :
+      Optional (List Text)
+  , onDemandAllocationStrategy :
+      Optional Text
+  , onDemandBase :
+      Optional Natural
+  , onDemandAboveBase :
+      Optional Natural
+  , spotAllocationStrategy :
+      Optional Text
+  , spotInstancePools :
+      Optional Text
+  }
+: Type

--- a/types/api/v1alpha2/package.dhall
+++ b/types/api/v1alpha2/package.dhall
@@ -82,6 +82,8 @@
     ./LoadBalancer.dhall
 , LoadBalancerAccessSpec =
     ./LoadBalancerAccessSpec.dhall
+, MixedInstancesPolicySpec =
+    ./MixedInstancesPolicySpec.dhall
 , Networking =
     ./networking/package.dhall
 , NetworkingSpec =


### PR DESCRIPTION
Adds support for [MixedInstancesPolicySpec](https://github.com/kubernetes/kops/blob/master/docs/instance_groups.md#creating-a-instance-group-of-mixed-instances-types-aws-only).