### PR TITLE
Add configuration in line with Kops 1.15.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This allows the user to more easily generate type-safe Kops configuration, throu
 ## Install
 For stability, users are encouraged to import from a tagged release, not from the master branch, and to watch for new releases. This project does not yet have rigorous testing set up for it and new commits on the master branch are prone to break compatiblility and are almost sure to change the import hash for the expression, thus the releases are currently `v0.x`.
 ```
-https://raw.githubusercontent.com/coralogix/dhall-kops/v0.4.1/package.dhall sha256:9f4c14955d59187599cd5af92464837c77aee8b363f152c8061ac3e59e40f9d2
+https://raw.githubusercontent.com/coralogix/dhall-kops/v0.5.0/package.dhall sha256:94d701a6b76fed1a66c2a155dd5de6214e381be141f99a44461c3ddb23bd5ec0
 ```
 
 ## Usage

--- a/api/v1alpha2/Channel.dhall
+++ b/api/v1alpha2/Channel.dhall
@@ -8,5 +8,5 @@ in  { Type =
         , metadata : Metadata.Type
         , spec : ChannelSpec.Type
         }
-    , default = { apiVersion = "kops/v1alpha2", kind = "Channel" }
+    , default = { apiVersion = "kops.k8s.io/v1alpha2", kind = "Channel" }
     }

--- a/api/v1alpha2/Cluster.dhall
+++ b/api/v1alpha2/Cluster.dhall
@@ -8,5 +8,5 @@ in  { Type =
         , metadata : Metadata.Type
         , spec : Spec.Type
         }
-    , default = { apiVersion = "kops/v1alpha2", kind = "Cluster" }
+    , default = { apiVersion = "kops.k8s.io/v1alpha2", kind = "Cluster" }
     }

--- a/api/v1alpha2/EtcdClusterSpec.dhall
+++ b/api/v1alpha2/EtcdClusterSpec.dhall
@@ -6,6 +6,8 @@ let EtcdManagerSpec = ./EtcdManagerSpec.dhall
 
 in  { Type =
         { name : Text
+        , cpuRequest : Optional Text
+        , memoryRequest : Optional Text
         , provider : Optional Text
         , etcdMembers : List EtcdMemberSpec.Type
         , enabledEtcdTLS : Optional Bool
@@ -19,6 +21,8 @@ in  { Type =
         }
     , default =
         { provider = None Text
+        , cpuRequest = None Text
+        , memoryRequest = None Text
         , enabledEtcdTLS = None Bool
         , enableTLSAuth = None Bool
         , version = None Text

--- a/api/v1alpha2/InstanceGroup.dhall
+++ b/api/v1alpha2/InstanceGroup.dhall
@@ -8,5 +8,5 @@ in  { Type =
         , metadata : Metadata.Type
         , spec : Spec.Type
         }
-    , default = { apiVersion = "kops/v1alpha2", kind = "InstanceGroup" }
+    , default = { apiVersion = "kops.k8s.io/v1alpha2", kind = "InstanceGroup" }
     }

--- a/api/v1alpha2/InstanceGroupSpec.dhall
+++ b/api/v1alpha2/InstanceGroupSpec.dhall
@@ -49,6 +49,7 @@ in  { Type =
         , detailedInstanceMonitoring : Optional Bool
         , iam : Optional IAMProfileSpec.Type
         , securityGroupOverride : Optional Text
+        , instanceProtection : Optional Bool
         }
     , default =
         { rootVolumeSize = None Natural
@@ -75,5 +76,6 @@ in  { Type =
         , iam = None IAMProfileSpec.Type
         , securityGroupOverride = None Text
         , zones = None (List Text)
+        , instanceProtection = None Bool
         }
     }

--- a/api/v1alpha2/KubeAPIServerConfig.dhall
+++ b/api/v1alpha2/KubeAPIServerConfig.dhall
@@ -11,8 +11,10 @@
     , enableBootstrapTokenAuth : Optional Bool
     , enableAggregatorRouting : Optional Bool
     , admissionControl : Optional (List Text)
+    , appendAdmissionPlugins : Optional (List Text)
     , enableAdmissionPlugins : Optional (List Text)
     , disableAdmissionPlugins : Optional (List Text)
+    , admissionControlConfigFile : Optional Text
     , serviceClusterIPRange : Optional Text
     , serviceNodePortRange : Optional Text
     , etcdServers : Optional (List Text)
@@ -24,6 +26,8 @@
     , clientCAFile : Optional Text
     , tlsCertFile : Optional Text
     , tlsPrivateKeyFile : Optional Text
+    , tlsCipherSuites : Optional (List Text)
+    , tlsMinVersion : Optional Text
     , tokenAuthFile : Optional Text
     , allowPrivileged : Optional Bool
     , apiServerCount : Optional Natural
@@ -39,6 +43,7 @@
     , oidcGroupsPrefix : Optional Text
     , oidcIssuerURL : Optional Text
     , oidcClientID : Optional Text
+    , oidcRequiredClaim : Optional (List Text)
     , oidcCAFile : Optional Text
     , proxyClientCertFile : Optional Text
     , proxyClientKeyFile : Optional Text
@@ -48,9 +53,20 @@
     , auditLogMaxBackups : Optional Natural
     , auditLogMaxSize : Optional Natural
     , auditPolicyFile : Optional Text
+    , auditWebhookBatchBufferSize : Optional Natural
+    , auditWebhookBatchMaxSize : Optional Natural
+    , auditWebhookBatchMaxWait : Optional Text
+    , auditWebhookBatchThrottleBurst : Optional Natural
+    , auditWebhookBatchThrottleQps : Optional Natural
+    , auditWebhookConfigFile : Optional Text
+    , auditWebhookInitialBackoff : Optional Text
+    , auditWebhookMode : Optional Text
     , authenticationTokenWebhookConfigFile : Optional Text
     , authenticationTokenWebhookCacheTtl : Optional Natural
     , authorizationMode : Optional Text
+    , authorizationWebhookConfigFile : Optional Text
+    , authorizationWebhookCacheAuthorizedTtl : Optional Text
+    , authorizationWebhookCacheUnauthorizedTtl : Optional Text
     , authorizationRbacSuperUser : Optional Text
     , experimentalEncryptionProviderConfig : Optional Text
     , requestheaderUsernameHeaders : Optional (List Text)
@@ -61,9 +77,15 @@
     , featureGates : Optional (List { mapKey : Text, mapValue : Text })
     , maxRequestsInflight : Optional Natural
     , maxMutatingRequestsInflight : Optional Natural
+    , http2MaxStreamsPerConnection : Optional Natural
     , etcdQuorumRead : Optional Bool
     , minRequestTimeout : Optional Natural
     , targetRamMb : Optional Natural
+    , serviceAccountKeyFile : Optional (List Text)
+    , serviceAccountSigningKeyFile : Optional Text
+    , serviceAccountIssuer : Optional Text
+    , apiAudiences : Optional (List Text)
+    , cpuRequest : Optional Text
     }
 , default =
     { image = None Text
@@ -78,8 +100,10 @@
     , enableBootstrapTokenAuth = None Bool
     , enableAggregatorRouting = None Bool
     , admissionControl = None (List Text)
+    , appendAdmissionPlugins = None (List Text)
     , enableAdmissionPlugins = None (List Text)
     , disableAdmissionPlugins = None (List Text)
+    , admissionControlConfigFile = None Text
     , serviceClusterIPRange = None Text
     , serviceNodePortRange = None Text
     , etcdServers = None (List Text)
@@ -91,6 +115,8 @@
     , clientCAFile = None Text
     , tlsCertFile = None Text
     , tlsPrivateKeyFile = None Text
+    , tlsCipherSuites = None (List Text)
+    , tlsMinVersion = None Text
     , tokenAuthFile = None Text
     , allowPrivileged = None Bool
     , apiServerCount = None Natural
@@ -106,6 +132,7 @@
     , oidcGroupsPrefix = None Text
     , oidcIssuerURL = None Text
     , oidcClientID = None Text
+    , oidcRequiredClaim = None (List Text)
     , oidcCAFile = None Text
     , proxyClientCertFile = None Text
     , proxyClientKeyFile = None Text
@@ -115,9 +142,20 @@
     , auditLogMaxBackups = None Natural
     , auditLogMaxSize = None Natural
     , auditPolicyFile = None Text
+    , auditWebhookBatchBufferSize = None Natural
+    , auditWebhookBatchMaxSize = None Natural
+    , auditWebhookBatchMaxWait = None Text
+    , auditWebhookBatchThrottleBurst = None Natural
+    , auditWebhookBatchThrottleQps = None Natural
+    , auditWebhookConfigFile = None Text
+    , auditWebhookInitialBackoff = None Text
+    , auditWebhookMode = None Text
     , authenticationTokenWebhookConfigFile = None Text
     , authenticationTokenWebhookCacheTtl = None Natural
     , authorizationMode = None Text
+    , authorizationWebhookConfigFile = None Text
+    , authorizationWebhookCacheAuthorizedTtl = None Text
+    , authorizationWebhookCacheUnauthorizedTtl = None Text
     , authorizationRbacSuperUser = None Text
     , experimentalEncryptionProviderConfig = None Text
     , requestheaderUsernameHeaders = None (List Text)
@@ -128,8 +166,14 @@
     , featureGates = None (List { mapKey : Text, mapValue : Text })
     , maxRequestsInflight = None Natural
     , maxMutatingRequestsInflight = None Natural
+    , http2MaxStreamsPerConnection = None Natural
     , etcdQuorumRead = None Bool
     , minRequestTimeout = None Natural
     , targetRamMb = None Natural
+    , serviceAccountKeyFile = None (List Text)
+    , serviceAccountSigningKeyFile = None Text
+    , serviceAccountIssuer = None Text
+    , apiAudiences = None (List Text)
+    , cpuRequest = None Text
     }
 }

--- a/api/v1alpha2/KubeControllerManagerConfig.dhall
+++ b/api/v1alpha2/KubeControllerManagerConfig.dhall
@@ -23,10 +23,16 @@ in  { Type =
         , useServiceAccountCredentials : Optional Bool
         , horizontalPodAutoscalerSyncPeriod : Optional Text
         , horizontalPodAutoscalerDownscaleDelay : Optional Text
+        , horizontalPodAutoscalerDownscaleStabilization : Optional Text
         , horizontalPodAutoscalerUpscaleDelay : Optional Text
         , horizontalPodAutoscalerTolerance : Optional Double
         , horizontalPodAutoscalerUseRestClients : Optional Bool
         , featureGates : Optional (List { mapKey : Text, mapValue : Text })
+        , tlsCipherSuites : Optional (List Text)
+        , tlsMinVersion : Optional Text
+        , minResyncPeriod : Optional Text
+        , kubeAPIQPS : Optional Natural
+        , kubeAPIBurst : Optional Natural
         }
     , default =
         { master = None Text
@@ -51,9 +57,15 @@ in  { Type =
         , useServiceAccountCredentials = None Bool
         , horizontalPodAutoscalerSyncPeriod = None Text
         , horizontalPodAutoscalerDownscaleDelay = None Text
+        , horizontalPodAutoscalerDownscaleStabilization = None Text
         , horizontalPodAutoscalerUpscaleDelay = None Text
         , horizontalPodAutoscalerTolerance = None Double
         , horizontalPodAutoscalerUseRestClients = None Bool
         , featureGates = None (List { mapKey : Text, mapValue : Text })
+        , tlsCipherSuites = None (List Text)
+        , tlsMinVersion = None Text
+        , minResyncPeriod = None Text
+        , kubeAPIQPS = None Natural
+        , kubeAPIBurst = None Natural
         }
     }

--- a/api/v1alpha2/KubeletConfigSpec.dhall
+++ b/api/v1alpha2/KubeletConfigSpec.dhall
@@ -8,6 +8,8 @@ in  { Type =
         , clientCaFile : Optional Text
         , tlsCertFile : Optional Text
         , tlsPrivateKeyFile : Optional Text
+        , tlsCipherSuites : Optional (List Text)
+        , tlsMinVersion : Optional Text
         , kubeconfigPath : Optional Text
         , requireKubeconfig : Optional Bool
         , logLevel : Optional Natural
@@ -69,6 +71,11 @@ in  { Type =
         , rootDir : Optional Text
         , authenticationTokenWebhook : Optional Bool
         , authenticationTokenWebhookCacheTtl : Optional Text
+        , cpuCFSQuota : Optional Bool
+        , cpuCFSQuotaPeriod : Optional Text
+        , cpuManagerPolicy : Optional Text
+        , registryPullQPS : Optional Natural
+        , registryBurst : Optional Natural
         }
     , default =
         { apiServers = None Text
@@ -78,6 +85,8 @@ in  { Type =
         , clientCaFile = None Text
         , tlsCertFile = None Text
         , tlsPrivateKeyFile = None Text
+        , tlsCipherSuites = None (List Text)
+        , tlsMinVersion = None Text
         , kubeconfigPath = None Text
         , requireKubeconfig = None Bool
         , logLevel = None Natural
@@ -139,5 +148,10 @@ in  { Type =
         , rootDir = None Text
         , authenticationTokenWebhook = None Bool
         , authenticationTokenWebhookCacheTtl = None Text
+        , cpuCFSQuota = None Bool
+        , cpuCFSQuotaPeriod = None Text
+        , cpuManagerPolicy = None Text
+        , registryPullQPS = None Natural
+        , registryBurst = None Natural
         }
     }

--- a/api/v1alpha2/LoadBalancerAccessSpec.dhall
+++ b/api/v1alpha2/LoadBalancerAccessSpec.dhall
@@ -5,6 +5,7 @@
     , additionalSecurityGroups : Optional (List Text)
     , useForInternalApi : Optional Bool
     , sslCertificate : Optional Text
+    , crossZoneLoadBalancing : Optional Bool
     }
 , default =
     { idleTimeoutSeconds = None Natural
@@ -12,5 +13,6 @@
     , additionalSecurityGroups = None (List Text)
     , useForInternalApi = None Bool
     , sslCertificate = None Text
+    , crossZoneLoadBalancing = None Bool
     }
 }

--- a/api/v1alpha2/NodeAuthorizerSpec.dhall
+++ b/api/v1alpha2/NodeAuthorizerSpec.dhall
@@ -4,6 +4,7 @@
     , image : Optional Text
     , nodeURL : Optional Text
     , port : Optional Natural
+    , interval : Optional Text
     , timeout : Optional Natural
     , tokenTTL : Optional Natural
     }
@@ -13,6 +14,7 @@
     , image = None Text
     , nodeURL = None Text
     , port = None Natural
+    , interval = None Text
     , timeout = None Natural
     , tokenTTL = None Natural
     }


### PR DESCRIPTION
------

Adds various configuration options which have been added to Kops as of
1.15.0. Of note, this includes the `kops/v1alpha2` ->
`kops.k8s.io/v1alpha2` change for the `apiVersion` field, which Kops
1.15.0 now expects.